### PR TITLE
Add zsh filetype for Vim

### DIFF
--- a/shayan.zsh-theme
+++ b/shayan.zsh-theme
@@ -1,3 +1,5 @@
+# vim:ft=zsh ts=2 sw=2 sts=2
+
 function prompt_char {
 	if [ $UID -eq 0 ]; then echo "#"; else echo %%; fi
 }


### PR DESCRIPTION
Add zsh filetype for VIM to highlight syntax.
Hope it helps.